### PR TITLE
Add support for syncing Schedules

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,6 +32,13 @@ var (
 		},
 		Annotations: annotationsForUserResourceType(),
 	}
+	resourceTypeSchedule = &v2.ResourceType{
+		Id:          "schedule",
+		DisplayName: "Schedule",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_GROUP,
+		},
+	}
 )
 
 type Opsgenie struct {
@@ -89,5 +96,6 @@ func (c *Opsgenie) ResourceSyncers(ctx context.Context) []connectorbuilder.Resou
 		teamBuilder(c.config),
 		roleBuilder(c.config),
 		userBuilder(c.config),
+		scheduleBuilder(c.config),
 	}
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -5,6 +5,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const ResourcesPageSize = 100
@@ -21,4 +22,37 @@ func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}
 	annos.Update(&v2.SkipEntitlementsAndGrants{})
 	return annos
+}
+
+func getProfileStringArray(profile *structpb.Struct, k string) ([]string, bool) {
+	var values []string
+	if profile == nil {
+		return nil, false
+	}
+
+	v, ok := profile.Fields[k]
+	if !ok {
+		return nil, false
+	}
+
+	s, ok := v.Kind.(*structpb.Value_ListValue)
+	if !ok {
+		return nil, false
+	}
+
+	for _, v := range s.ListValue.Values {
+		if strVal := v.GetStringValue(); strVal != "" {
+			values = append(values, strVal)
+		}
+	}
+
+	return values, true
+}
+
+func scheduleParticipantsToInterfaceSlice(p []string) []interface{} {
+	var i []interface{}
+	for _, v := range p {
+		i = append(i, v)
+	}
+	return i
 }

--- a/pkg/connector/schedule.go
+++ b/pkg/connector/schedule.go
@@ -1,0 +1,221 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	ogClient "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+	ogSchedule "github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
+)
+
+const (
+	scheduleMember = "member"
+	scheduleOnCall = "on-call"
+
+	rotationUserParticipantType = "user"
+	rotationTeamParticipantType = "team"
+)
+
+type scheduleResourceType struct {
+	resourceType *v2.ResourceType
+	config       *ogClient.Config
+}
+
+func (s *scheduleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return s.resourceType
+}
+
+// parses array of rotations and returns all teams and users that participate in rotations.
+func parseRotations(rotation []og.Rotation) ([]string, []string) {
+	var teams, users []string
+
+	for _, r := range rotation {
+		for _, p := range r.Participants {
+			if p.Type == rotationTeamParticipantType {
+				teams = append(teams, p.Id)
+			} else if p.Type == rotationUserParticipantType {
+				users = append(users, p.Id)
+			}
+		}
+	}
+
+	return teams, users
+}
+
+// scheduleResource creates a new connector resource for a OpsGenie Schedule.
+func scheduleResource(schedule *ogSchedule.Schedule) (*v2.Resource, error) {
+	profile := map[string]interface{}{
+		"schedule_id":   schedule.Id,
+		"schedule_name": schedule.Name,
+	}
+
+	teams, users := parseRotations(schedule.Rotations)
+
+	if len(teams) > 0 {
+		profile["schedule_teams"] = scheduleParticipantsToInterfaceSlice(teams)
+	}
+
+	if len(users) > 0 {
+		profile["schedule_users"] = scheduleParticipantsToInterfaceSlice(users)
+	}
+
+	resource, err := rs.NewGroupResource(
+		schedule.Name,
+		resourceTypeSchedule,
+		schedule.Id,
+		[]rs.GroupTraitOption{rs.WithGroupProfile(profile)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+func (s *scheduleResourceType) List(ctx context.Context, parentID *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	client, err := ogSchedule.NewClient(s.config)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	expand := true
+	req := &ogSchedule.ListRequest{
+		BaseRequest: ogClient.BaseRequest{},
+		Expand:      &expand,
+	}
+	schedules, err := client.List(ctx, req)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("opsgenie-connector: failed to list schedules: %w", err)
+	}
+
+	var rv []*v2.Resource
+	for _, schedule := range schedules.Schedule {
+		scheduleCopy := schedule
+
+		sr, err := scheduleResource(&scheduleCopy)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		rv = append(rv, sr)
+	}
+
+	return rv, "", nil, nil
+}
+
+func (s *scheduleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	var rv []*v2.Entitlement
+
+	memberEntitlementOptions := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeUser, resourceTypeTeam),
+		ent.WithDisplayName(fmt.Sprintf("%s schedule %s", resource.DisplayName, scheduleMember)),
+		ent.WithDescription(fmt.Sprintf("%s OpsGenie schedule %s", resource.DisplayName, scheduleMember)),
+	}
+
+	oncallEntitlementOptions := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeUser),
+		ent.WithDisplayName(fmt.Sprintf("%s schedule %s", resource.DisplayName, scheduleOnCall)),
+		ent.WithDescription(fmt.Sprintf("%s OpsGenie schedule %s", resource.DisplayName, scheduleOnCall)),
+	}
+
+	rv = append(
+		rv,
+		ent.NewAssignmentEntitlement(resource, scheduleMember, memberEntitlementOptions...),
+		ent.NewAssignmentEntitlement(resource, scheduleOnCall, oncallEntitlementOptions...),
+	)
+
+	return rv, "", nil, nil
+}
+
+func (s *scheduleResourceType) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	// parse resource profile to get schedule members (users or teams) and grant them the member entitlement
+	groupTrait, err := rs.GetGroupTrait(resource)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	users, ok := getProfileStringArray(groupTrait.Profile, "schedule_users")
+	if !ok {
+		l.Info("opsgenie-connector: no users found for schedule resource")
+	}
+
+	teams, ok := getProfileStringArray(groupTrait.Profile, "schedule_teams")
+	if !ok {
+		l.Info("opsgenie-connector: no teams found for schedule resource")
+	}
+
+	var rv []*v2.Grant
+	for _, u := range users {
+		rv = append(rv, grant.NewGrant(
+			resource,
+			scheduleMember,
+			&v2.ResourceId{
+				ResourceType: resourceTypeUser.Id,
+				Resource:     u,
+			},
+		))
+	}
+
+	for _, t := range teams {
+		rv = append(rv, grant.NewGrant(
+			resource,
+			scheduleMember,
+			&v2.ResourceId{
+				ResourceType: resourceTypeTeam.Id,
+				Resource:     t,
+			},
+			grant.WithAnnotation(
+				&v2.GrantExpandable{
+					EntitlementIds: []string{fmt.Sprintf("team:%s:%s", t, scheduleMember)},
+				},
+			),
+		))
+	}
+
+	now := time.Now()
+	// hourFromNow := now.Add(time.Hour)
+
+	client, err := ogSchedule.NewClient(s.config)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	flat := true
+	req := &ogSchedule.GetOnCallsRequest{
+		BaseRequest:        ogClient.BaseRequest{},
+		Flat:               &flat,
+		Date:               &now,
+		ScheduleIdentifier: resource.DisplayName,
+	}
+
+	// TODO: finish this
+	oncalls, err := client.GetOnCalls(ctx, req)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("opsgenie-connector: failed to list on-calls: %w", err)
+	}
+
+	fmt.Printf("LISTING ON CALLS:\n%+v\n", oncalls)
+	for _, participant := range oncalls.OnCallRecipients {
+		fmt.Printf("oncall: %+v\n", participant)
+	}
+
+	return rv, "", nil, nil
+}
+
+func scheduleBuilder(config *ogClient.Config) *scheduleResourceType {
+	return &scheduleResourceType{
+		resourceType: resourceTypeSchedule,
+		config:       config,
+	}
+}

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -101,27 +101,26 @@ func (o *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		return nil, "", nil, err
 	}
 
-	teams, err := teamClient.List(ctx, &oteam.ListTeamRequest{BaseRequest: ogclient.BaseRequest{}})
+	getTeamRequest := &oteam.GetTeamRequest{
+		BaseRequest:     ogclient.BaseRequest{},
+		IdentifierValue: resource.Id.Resource,
+		IdentifierType:  oteam.Identifier(idIdentifierType),
+	}
+
+	t, err := teamClient.Get(ctx, getTeamRequest)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
-	for _, team := range teams.Teams {
-		teamWithMembers, err := teamClient.Get(ctx, &oteam.GetTeamRequest{BaseRequest: ogclient.BaseRequest{}, IdentifierValue: team.Id, IdentifierType: oteam.Identifier(idIdentifierType)})
-		if err != nil {
-			return nil, "", nil, err
-		}
-
-		for _, member := range teamWithMembers.Members {
-			rv = append(rv, grant.NewGrant(
-				resource,
-				teamMemberEntitlement,
-				&v2.ResourceId{
-					ResourceType: resourceTypeUser.Id,
-					Resource:     member.User.ID,
-				},
-			))
-		}
+	for _, member := range t.Members {
+		rv = append(rv, grant.NewGrant(
+			resource,
+			teamMemberEntitlement,
+			&v2.ResourceId{
+				ResourceType: resourceTypeUser.Id,
+				Resource:     member.User.ID,
+			},
+		))
 	}
 
 	return rv, "", nil, nil

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/request.go
@@ -1,0 +1,550 @@
+package schedule
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+	"github.com/pkg/errors"
+)
+
+type Identifier uint32
+
+type CreateRequest struct {
+	client.BaseRequest
+	Name        string        `json:"name"`
+	Description string        `json:"description,omitempty"`
+	Timezone    string        `json:"timezone,omitempty"`
+	Enabled     *bool         `json:"enabled,omitempty"`
+	OwnerTeam   *og.OwnerTeam `json:"ownerTeam,omitempty"`
+	Rotations   []og.Rotation `json:"rotations,omitempty"`
+}
+
+func (r *CreateRequest) Validate() error {
+	if r.Name == "" {
+		return errors.New("Name cannot be empty.")
+	}
+	err := og.ValidateRotations(r.Rotations)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CreateRequest) ResourcePath() string {
+	return "/v2/schedules"
+}
+
+func (r *CreateRequest) Method() string {
+	return http.MethodPost
+}
+
+type GetRequest struct {
+	client.BaseRequest
+	IdentifierType  Identifier
+	IdentifierValue string
+}
+
+func (r *GetRequest) Validate() error {
+	err := validateIdentifier(r.IdentifierValue)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *GetRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.IdentifierValue
+}
+
+func (r *GetRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.IdentifierType == Name {
+		params["identifierType"] = "name"
+	} else {
+		params["identifierType"] = "id"
+	}
+
+	return params
+}
+
+type UpdateRequest struct {
+	client.BaseRequest
+	IdentifierType  Identifier
+	IdentifierValue string
+	Name            string        `json:"name, omitempty"`
+	Description     string        `json:"description,omitempty"`
+	Timezone        string        `json:"timezone,omitempty"`
+	Enabled         *bool         `json:"enabled,omitempty"`
+	OwnerTeam       *og.OwnerTeam `json:"ownerTeam,omitempty"`
+	Rotations       []og.Rotation `json:"rotations,omitempty"`
+}
+
+func (r *UpdateRequest) Validate() error {
+	err := validateIdentifier(r.IdentifierValue)
+	if err != nil {
+		return err
+	}
+	err = og.ValidateRotations(r.Rotations)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *UpdateRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.IdentifierValue
+}
+
+func (r *UpdateRequest) Method() string {
+	return http.MethodPatch
+}
+
+func (r *UpdateRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.IdentifierType == Name {
+		params["identifierType"] = "name"
+	} else {
+		params["identifierType"] = "id"
+	}
+
+	return params
+}
+
+type DeleteRequest struct {
+	client.BaseRequest
+	IdentifierType  Identifier
+	IdentifierValue string
+}
+
+func (r *DeleteRequest) Validate() error {
+	err := validateIdentifier(r.IdentifierValue)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *DeleteRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.IdentifierValue
+}
+
+func (r *DeleteRequest) Method() string {
+	return http.MethodDelete
+}
+
+func (r *DeleteRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.IdentifierType == Name {
+		params["identifierType"] = "name"
+	} else {
+		params["identifierType"] = "id"
+	}
+
+	return params
+}
+
+type ListRequest struct {
+	client.BaseRequest
+	Expand *bool
+}
+
+func (r *ListRequest) Validate() error {
+	return nil
+}
+
+func (r *ListRequest) ResourcePath() string {
+
+	return "/v2/schedules"
+}
+
+func (r *ListRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *ListRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if *r.Expand {
+		params["expand"] = "rotation"
+
+	}
+
+	return params
+}
+
+type GetTimelineRequest struct {
+	client.BaseRequest
+	IdentifierType  Identifier
+	IdentifierValue string
+	Expands         []ExpandType
+	Interval        int
+	IntervalUnit    Unit
+	Date            *time.Time
+}
+
+func (r *GetTimelineRequest) Validate() error {
+	err := validateIdentifier(r.IdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	if r.IntervalUnit != Days && r.IntervalUnit != Months && r.IntervalUnit != Weeks {
+		return errors.New("Provided InternalUnit is not valid.")
+	}
+	return nil
+}
+
+func (r *GetTimelineRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.IdentifierValue + "/timeline"
+
+}
+
+func (r *GetTimelineRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetTimelineRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.IdentifierType == Name {
+		params["identifierType"] = "name"
+	} else {
+		params["identifierType"] = "id"
+	}
+
+	if len(r.Expands) != 0 {
+		expands := ""
+		for i, expand := range r.Expands {
+			if i != len(r.Expands)-1 {
+				expands = expands + string(expand) + ","
+			} else {
+				expands = expands + string(expand)
+			}
+		}
+		params["expand"] = expands
+	}
+
+	if r.Interval > 1 {
+		params["interval"] = strconv.Itoa(r.Interval)
+	}
+	params["intervalUnit"] = string(r.IntervalUnit)
+
+	if r.Date != nil {
+		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+	}
+	return params
+}
+
+func (r *GetTimelineRequest) WithExpands(expands ...ExpandType) GetTimelineRequest {
+	r.Expands = expands
+	return *r
+}
+
+type ExportScheduleRequest struct {
+	client.BaseRequest
+	IdentifierType   Identifier
+	IdentifierValue  string
+	ExportedFilePath string
+}
+
+func (r *ExportScheduleRequest) Validate() error {
+	err := validateIdentifier(r.IdentifierValue)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ExportScheduleRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *ExportScheduleRequest) getFileName() string {
+	return r.IdentifierValue + ".ics"
+}
+
+func (r *ExportScheduleRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.getFileName()
+}
+
+func (r *ExportScheduleRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.IdentifierType == Name {
+		params["identifierType"] = "name"
+	} else {
+		params["identifierType"] = "id"
+	}
+
+	return params
+}
+
+type Unit string
+
+const (
+	Months Unit = "months"
+	Weeks  Unit = "weeks"
+	Days   Unit = "days"
+)
+
+type ExpandType string
+
+const (
+	Base       ExpandType = "base"
+	Forwarding ExpandType = "forwarding"
+	Override   ExpandType = "override"
+)
+
+const (
+	Name Identifier = iota
+	Id
+)
+
+func (r *CreateRequest) WithRotation(rotation *og.Rotation) *CreateRequest {
+	r.Rotations = append(r.Rotations, *rotation)
+	return r
+}
+
+func (r *UpdateRequest) WithRotation(rotation *og.Rotation) *UpdateRequest {
+	r.Rotations = append(r.Rotations, *rotation)
+	return r
+}
+
+func validateIdentifier(identifier string) error {
+	if identifier == "" {
+		return errors.New("Schedule identifier cannot be empty.")
+	}
+	return nil
+}
+
+//schedule rotation
+type CreateRotationRequest struct {
+	*og.Rotation
+	ScheduleIdentifierType  Identifier
+	ScheduleIdentifierValue string
+}
+
+func (r *CreateRotationRequest) Validate() error {
+	err := validateIdentifier(r.ScheduleIdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	err = r.Rotation.Validate()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CreateRotationRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.ScheduleIdentifierValue + "/rotations"
+
+}
+
+func (r *CreateRotationRequest) Method() string {
+	return http.MethodPost
+}
+
+func (r *CreateRotationRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type GetRotationRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType  Identifier
+	ScheduleIdentifierValue string
+	RotationId              string
+}
+
+func (r *GetRotationRequest) Validate() error {
+
+	err := validateIdentifier(r.ScheduleIdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	if r.RotationId == "" {
+		return errors.New("Rotation Id cannot be empty.")
+	}
+
+	return nil
+}
+
+func (r *GetRotationRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.ScheduleIdentifierValue + "/rotations/" + r.RotationId
+
+}
+
+func (r *GetRotationRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetRotationRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type UpdateRotationRequest struct {
+	ScheduleIdentifierType  Identifier
+	ScheduleIdentifierValue string
+	RotationId              string
+	*og.Rotation
+}
+
+func (r *UpdateRotationRequest) Validate() error {
+
+	err := validateIdentifier(r.ScheduleIdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	if r.RotationId == "" {
+		return errors.New("Rotation Id cannot be empty.")
+	}
+
+	return nil
+}
+
+func (r *UpdateRotationRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifierValue + "/rotations/" + r.RotationId
+
+}
+
+func (r *UpdateRotationRequest) Method() string {
+	return http.MethodPatch
+}
+
+func (r *UpdateRotationRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type DeleteRotationRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType  Identifier
+	ScheduleIdentifierValue string
+	RotationId              string
+}
+
+func (r *DeleteRotationRequest) Validate() error {
+
+	err := validateIdentifier(r.ScheduleIdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	if r.RotationId == "" {
+		return errors.New("Rotation Id cannot be empty.")
+	}
+
+	return nil
+}
+
+func (r *DeleteRotationRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifierValue + "/rotations/" + r.RotationId
+
+}
+
+func (r *DeleteRotationRequest) Method() string {
+	return http.MethodDelete
+}
+
+func (r *DeleteRotationRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type ListRotationsRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType  Identifier
+	ScheduleIdentifierValue string
+}
+
+func (r *ListRotationsRequest) Validate() error {
+
+	err := validateIdentifier(r.ScheduleIdentifierValue)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ListRotationsRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifierValue + "/rotations"
+
+}
+
+func (r *ListRotationsRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *ListRotationsRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/responder.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/responder.go
@@ -1,0 +1,45 @@
+package schedule
+
+type ResponderType string
+
+const (
+	UserResponderType       ResponderType = "user"
+	TeamResponderType       ResponderType = "team"
+	EscalationResponderType ResponderType = "escalation"
+	ScheduleResponderType   ResponderType = "schedule"
+)
+
+type Responder struct {
+	Type     ResponderType `json:"type, omitempty"`
+	Name     string        `json:"name,omitempty"`
+	Id       string        `json:"id,omitempty"`
+	Username string        `json:"username, omitempty"`
+}
+
+type TeamResponder struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type UserResponder struct {
+	ID       string `json:"id,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type EscalationResponder struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type ScheduleResponder struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+func (s *ScheduleResponder) SetID(id string) {
+	s.ID = id
+}
+
+func (s *ScheduleResponder) SetUsername(name string) {
+	s.Name = name
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/result.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/result.go
@@ -1,0 +1,142 @@
+package schedule
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+)
+
+type Schedule struct {
+	Id          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description,omitempty"`
+	Timezone    string        `json:"timezone,omitempty"`
+	Enabled     bool          `json:"enabled"`
+	OwnerTeam   *og.OwnerTeam `json:"ownerTeam,omitempty"`
+	Rotations   []og.Rotation `json:"rotations,omitempty"`
+}
+type CreateResult struct {
+	client.ResultMetadata
+	Id      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+}
+
+type GetResult struct {
+	client.ResultMetadata
+	Schedule Schedule `json:"data,omitempty"`
+}
+
+type UpdateResult struct {
+	client.ResultMetadata
+	Id      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+}
+
+type DeleteResult struct {
+	client.ResultMetadata
+	Result string `json:"result,omitempty"`
+}
+
+type ListResult struct {
+	client.ResultMetadata
+	Schedule         []Schedule `json:"data,omitempty"`
+	ExpandableFields []string   `json:"expandable,omitempty"`
+}
+
+type TimelineResult struct {
+	client.ResultMetadata
+	ScheduleInfo       Info         `json:"_parent"`
+	Description        string       `json:"description"`
+	OwnerTeam          og.OwnerTeam `json:"ownerTeam,omitempty"`
+	StartDate          time.Time    `json:"startDate,omitempty"`
+	EndDate            time.Time    `json:"endDate,omitempty"`
+	FinalTimeline      Timeline     `json:"finalTimeline,omitempty"`
+	BaseTimeline       Timeline     `json:"baseTimeline,omitempty"`
+	OverrideTimeline   Timeline     `json:"overrideTimeline,omitempty"`
+	ForwardingTimeline Timeline     `json:"forwardingTimeline,omitempty"`
+	ExpandableFields   []string     `json:"expandable,omitempty"`
+}
+
+type Timeline struct {
+	Rotations []TimelineRotation `json:"rotations,omitempty"`
+}
+
+type TimelineRotation struct {
+	Id      string   `json:"id,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	Order   float32  `json:"order,omitempty"`
+	Periods []Period `json:"periods,omitempty"`
+}
+
+type exportScheduleResult struct {
+	client.ResultMetadata
+	FileContent []byte
+}
+
+func (rm *exportScheduleResult) Parse(response *http.Response, result client.ApiResult) error {
+
+	if response == nil {
+		return errors.New("No response received")
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	result.(*exportScheduleResult).FileContent = body
+
+	return nil
+}
+
+type Info struct {
+	Id      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+}
+
+type Period struct {
+	StartDate time.Time      `json:"startDate,omitempty"`
+	EndDate   time.Time      `json:"endDate,omitempty"`
+	Type      string         `json:"type,omitempty"`
+	Recipient og.Participant `json:"recipient,omitempty"`
+}
+
+type Rotation struct {
+	Id              string              `json:"id,omitempty"`
+	Name            string              `json:"name,omitempty"`
+	StartDate       *time.Time          `json:"startDate,omitempty"`
+	EndDate         *time.Time          `json:"endDate,omitempty"`
+	Type            og.RotationType     `json:"type,omitempty"`
+	Length          uint32              `json:"length,omitempty"`
+	Participants    []og.Participant    `json:"participants,omitempty"`
+	TimeRestriction *og.TimeRestriction `json:"timeRestriction,omitempty"`
+}
+
+type CreateRotationResult struct {
+	client.ResultMetadata
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type GetRotationResult struct {
+	client.ResultMetadata
+	Rotation
+	Info `json:"_parent,omitempty"`
+}
+
+type UpdateRotationResult struct {
+	client.ResultMetadata
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type ListRotationsResult struct {
+	client.ResultMetadata
+	Rotations []Rotation `json:"data,omitempty"`
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule.go
@@ -1,0 +1,95 @@
+package schedule
+
+import (
+	"context"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"os"
+)
+
+type Client struct {
+	client *client.OpsGenieClient
+}
+
+func NewClient(config *client.Config) (*Client, error) {
+	opsgenieClient, err := client.NewOpsGenieClient(config)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{opsgenieClient}, nil
+}
+
+func (c *Client) Create(context context.Context, request *CreateRequest) (*CreateResult, error) {
+	result := &CreateResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) Get(context context.Context, request *GetRequest) (*GetResult, error) {
+	result := &GetResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) Update(context context.Context, request *UpdateRequest) (*UpdateResult, error) {
+	result := &UpdateResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) Delete(context context.Context, request *DeleteRequest) (*DeleteResult, error) {
+	result := &DeleteResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) List(context context.Context, request *ListRequest) (*ListResult, error) {
+	result := &ListResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) GetTimeline(context context.Context, request *GetTimelineRequest) (*TimelineResult, error) {
+	result := &TimelineResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) ExportSchedule(context context.Context, request *ExportScheduleRequest) (*os.File, error) {
+	result := &exportScheduleResult{}
+
+	file, err := os.Create(request.ExportedFilePath + request.getFileName())
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+	err = c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Write(result.FileContent)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override.go
@@ -1,0 +1,50 @@
+package schedule
+
+import (
+	"context"
+)
+
+func (c *Client) CreateScheduleOverride(context context.Context, request *CreateScheduleOverrideRequest) (*CreateScheduleOverrideResult, error) {
+	result := &CreateScheduleOverrideResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) GetScheduleOverride(context context.Context, request *GetScheduleOverrideRequest) (*GetScheduleOverrideResult, error) {
+	result := &GetScheduleOverrideResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) ListScheduleOverride(context context.Context, request *ListScheduleOverrideRequest) (*ListScheduleOverrideResult, error) {
+	result := &ListScheduleOverrideResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) DeleteScheduleOverride(context context.Context, request *DeleteScheduleOverrideRequest) (*DeleteScheduleOverrideResult, error) {
+	result := &DeleteScheduleOverrideResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) UpdateScheduleOverride(context context.Context, request *UpdateScheduleOverrideRequest) (*UpdateScheduleOverrideResult, error) {
+	result := &UpdateScheduleOverrideResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override_request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override_request.go
@@ -1,0 +1,262 @@
+package schedule
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
+
+type RotationIdentifier struct {
+	Id   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+type CreateScheduleOverrideRequest struct {
+	client.BaseRequest
+	Alias                  string               `json:"alias,omitempty"`
+	User                   Responder            `json:"user,omitempty"`
+	StartDate              time.Time            `json:"startDate,omitempty"`
+	EndDate                time.Time            `json:"endDate,omitempty"`
+	Rotations              []RotationIdentifier `json:"rotations,omitempty"`
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+}
+
+func (r *CreateScheduleOverrideRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateUser(&r.User)
+	if err != nil {
+		return err
+	}
+	err = validateDates(&r.StartDate, "Start date cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateDates(&r.EndDate, "End date cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CreateScheduleOverrideRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/overrides"
+}
+
+func (r *CreateScheduleOverrideRequest) Method() string {
+	return http.MethodPost
+}
+
+func (r *CreateScheduleOverrideRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type GetScheduleOverrideRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+	Alias                  string
+}
+
+func (r *GetScheduleOverrideRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateIdentifiers(r.Alias, "Alias cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *GetScheduleOverrideRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/overrides/" + r.Alias
+}
+
+func (r *GetScheduleOverrideRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetScheduleOverrideRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type ListScheduleOverrideRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+}
+
+func (r *ListScheduleOverrideRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ListScheduleOverrideRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/overrides"
+}
+
+func (r *ListScheduleOverrideRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *ListScheduleOverrideRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type DeleteScheduleOverrideRequest struct {
+	client.BaseRequest
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+	Alias                  string
+}
+
+func (r *DeleteScheduleOverrideRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateIdentifiers(r.Alias, "Alias cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *DeleteScheduleOverrideRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/overrides/" + r.Alias
+}
+
+func (r *DeleteScheduleOverrideRequest) Method() string {
+	return http.MethodDelete
+}
+
+func (r *DeleteScheduleOverrideRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+type UpdateScheduleOverrideRequest struct {
+	client.BaseRequest
+	Alias                  string
+	User                   Responder            `json:"user,omitempty"`
+	StartDate              time.Time            `json:"startDate,omitempty"`
+	EndDate                time.Time            `json:"endDate,omitempty"`
+	Rotations              []RotationIdentifier `json:"rotations,omitempty"`
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+}
+
+func (r *UpdateScheduleOverrideRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateIdentifiers(r.Alias, "Alias cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateUser(&r.User)
+	if err != nil {
+		return err
+	}
+	err = validateDates(&r.StartDate, "Start date cannot be empty.")
+	if err != nil {
+		return err
+	}
+	err = validateDates(&r.EndDate, "End date cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *UpdateScheduleOverrideRequest) ResourcePath() string {
+
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/overrides/" + r.Alias
+}
+
+func (r *UpdateScheduleOverrideRequest) Method() string {
+	return http.MethodPut
+}
+
+func (r *UpdateScheduleOverrideRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+
+	return params
+}
+
+func validateIdentifiers(identifier string, message string) error {
+	if identifier == "" {
+		return errors.New(message)
+	}
+	return nil
+}
+
+func validateUser(user *Responder) error {
+	if *user == (Responder{}) {
+		return errors.New("User cannot be empty.")
+	}
+	return nil
+}
+
+func validateDates(date *time.Time, message string) error {
+	if *date == (time.Time{}) {
+		return errors.New(message)
+	}
+	return nil
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override_result.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_override_result.go
@@ -1,0 +1,46 @@
+package schedule
+
+import (
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"time"
+)
+
+type ScheduleMeta struct {
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+type ScheduleOverride struct {
+	Parent    ScheduleMeta         `json:"_parent,omitempty"`
+	Alias     string               `json:"alias"`
+	User      Responder            `json:"user"`
+	StartDate time.Time            `json:"startDate"`
+	EndDate   time.Time            `json:"endDate"`
+	Rotations []RotationIdentifier `json:"rotations"`
+}
+
+type CreateScheduleOverrideResult struct {
+	client.ResultMetadata
+	Alias string `json:"alias"`
+}
+
+type GetScheduleOverrideResult struct {
+	client.ResultMetadata
+	ScheduleOverride
+}
+
+type ListScheduleOverrideResult struct {
+	client.ResultMetadata
+	ScheduleOverride []ScheduleOverride `json:"data,omitempty"`
+}
+
+type DeleteScheduleOverrideResult struct {
+	client.ResultMetadata
+	Result string `json:"result,omitempty"`
+}
+
+type UpdateScheduleOverrideResult struct {
+	client.ResultMetadata
+	Alias string `json:"alias"`
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_rotation.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/schedule_rotation.go
@@ -1,0 +1,48 @@
+package schedule
+
+import "context"
+
+func (c *Client) CreateRotation(context context.Context, request *CreateRotationRequest) (*CreateRotationResult, error) {
+	result := &CreateRotationResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) GetRotation(context context.Context, request *GetRotationRequest) (*GetRotationResult, error) {
+	result := &GetRotationResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) UpdateRotation(context context.Context, request *UpdateRotationRequest) (*UpdateRotationResult, error) {
+	result := &UpdateRotationResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) DeleteRotation(context context.Context, request *DeleteRotationRequest) (*DeleteResult, error) {
+	result := &DeleteResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) ListRotations(context context.Context, request *ListRotationsRequest) (*ListRotationsResult, error) {
+	result := &ListRotationsResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall.go
@@ -1,0 +1,47 @@
+package schedule
+
+import (
+	"context"
+	"os"
+)
+
+func (c *Client) GetOnCalls(context context.Context, request *GetOnCallsRequest) (*GetOnCallsResult, error) {
+	result := &GetOnCallsResult{}
+	err := c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) GetNextOnCall(context context.Context, request *GetNextOnCallsRequest) (*GetNextOnCallsResult, error) {
+	result := &GetNextOnCallsResult{}
+	err := c.client.Exec(context, request, result)
+
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) ExportOnCallUser(context context.Context, request *ExportOnCallUserRequest) (*os.File, error) {
+	result := &exportOncallUserResult{}
+
+	file, err := os.Create(request.ExportedFilePath + request.getFileName())
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+	err = c.client.Exec(context, request, result)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Write(result.FileContent)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall_request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall_request.go
@@ -1,0 +1,122 @@
+package schedule
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+)
+
+type GetOnCallsRequest struct {
+	client.BaseRequest
+	Flat                   *bool
+	Date                   *time.Time
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+}
+
+func (r *GetOnCallsRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *GetOnCallsRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetOnCallsRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/on-calls"
+}
+
+func (r *GetOnCallsRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+	if *r.Flat {
+		params["flat"] = "true"
+	}
+
+	if r.Date != nil {
+		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+	}
+
+	return params
+}
+
+type GetNextOnCallsRequest struct {
+	client.BaseRequest
+	Flat                   *bool
+	Date                   *time.Time
+	ScheduleIdentifierType Identifier
+	ScheduleIdentifier     string
+}
+
+func (r *GetNextOnCallsRequest) Validate() error {
+	err := validateIdentifiers(r.ScheduleIdentifier, "Schedule identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *GetNextOnCallsRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetNextOnCallsRequest) ResourcePath() string {
+	return "/v2/schedules/" + r.ScheduleIdentifier + "/next-on-calls"
+}
+
+func (r *GetNextOnCallsRequest) RequestParams() map[string]string {
+
+	params := make(map[string]string)
+
+	if r.ScheduleIdentifierType == Name {
+		params["scheduleIdentifierType"] = "name"
+	} else {
+		params["scheduleIdentifierType"] = "id"
+	}
+	if *r.Flat {
+		params["flat"] = "true"
+	}
+
+	if r.Date != nil {
+		params["date"] = r.Date.Format("2006-01-02T15:04:05.000Z")
+	}
+
+	return params
+}
+
+type ExportOnCallUserRequest struct {
+	client.BaseRequest
+	UserIdentifier   string
+	ExportedFilePath string
+}
+
+func (r *ExportOnCallUserRequest) Validate() error {
+	err := validateIdentifiers(r.UserIdentifier, "User identifier cannot be empty.")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ExportOnCallUserRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *ExportOnCallUserRequest) getFileName() string {
+	return r.UserIdentifier + ".ics"
+}
+
+func (r *ExportOnCallUserRequest) ResourcePath() string {
+	return "/v2/schedules/on-calls/" + r.getFileName()
+}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall_result.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/schedule/who_is_oncall_result.go
@@ -1,0 +1,70 @@
+package schedule
+
+import (
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+)
+
+type GetOnCallsResult struct {
+	client.ResultMetadata
+	Parent             ScheduleMeta           `json:"_parent,omitempty"`
+	OnCallParticipants []GetOnCallParticipant `json:"onCallParticipants,omitempty"`
+	OnCallRecipients   []string               `json:"onCallRecipients,omitempty"`
+}
+
+type GetOnCallParticipant struct {
+	Type               og.ParticipantType  `json:"type, omitempty"`
+	Name               string              `json:"name,omitempty"`
+	Id                 string              `json:"id,omitempty"`
+	EscalationTime     uint32              `json:"escalationTime,omitempty"`
+	NotifyType         og.NotifyType       `json:"notifyType,omitempty"`
+	OnCallParticipants []OnCallParticipant `json:"onCallParticipants,omitempty"`
+}
+
+type OnCallParticipant struct {
+	Type           og.ParticipantType `json:"type, omitempty"`
+	Name           string             `json:"name,omitempty"`
+	Id             string             `json:"id,omitempty"`
+	EscalationTime uint32             `json:"escalationTime,omitempty"`
+	NotifyType     og.NotifyType      `json:"notifyType,omitempty"`
+}
+
+type GetNextOnCallsResult struct {
+	client.ResultMetadata
+	Parent                      ScheduleMeta           `json:"_parent,omitempty"`
+	NextOnCallRecipients        []NextOnCallRecipients `json:"nextOnCallRecipients,omitempty"`
+	ExactNextOnCallRecipients   []NextOnCallRecipients `json:"exactNextOnCallRecipients,omitempty"`
+	NextOncallParticipants      []string               `json:"nextOnCallParticipants,omitempty"`
+	ExactNextOnCallParticipants []string               `json:"exactNextOnCallParticipants,omitempty"`
+}
+
+type NextOnCallRecipients struct {
+	Type               og.ParticipantType  `json:"type, omitempty"`
+	Name               string              `json:"name,omitempty"`
+	Id                 string              `json:"id,omitempty"`
+	ForwardedFrom      []og.Participant    `json:"forwardedFrom,omitempty"`
+	OnCallParticipants []OnCallParticipant `json:"onCallParticipants,omitempty"`
+}
+
+type exportOncallUserResult struct {
+	client.ResultMetadata
+	FileContent []byte
+}
+
+func (rm *exportOncallUserResult) Parse(response *http.Response, result client.ApiResult) error {
+
+	if response == nil {
+		return errors.New("No response received")
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	result.(*exportOncallUserResult).FileContent = body
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,6 +261,7 @@ github.com/opsgenie/opsgenie-go-sdk-v2/alert
 github.com/opsgenie/opsgenie-go-sdk-v2/client
 github.com/opsgenie/opsgenie-go-sdk-v2/custom_user_role
 github.com/opsgenie/opsgenie-go-sdk-v2/og
+github.com/opsgenie/opsgenie-go-sdk-v2/schedule
 github.com/opsgenie/opsgenie-go-sdk-v2/team
 github.com/opsgenie/opsgenie-go-sdk-v2/user
 # github.com/pelletier/go-toml/v2 v2.1.0


### PR DESCRIPTION
This PR adds new resource type: `schedule` and implements syncing of new entitlements and grants under it. It implements similar feature request as in [PagerDuty](https://github.com/ConductorOne/baton-pagerduty/issues/11).

As I implemented this, I found two problems:
- rate-limits within my free plan - implemented exponential backoff (https://github.com/ConductorOne/baton-opsgenie/pull/3/commits/8e560f0ad81d26baa0aeef86ff3130d917403dee)
- incorrect syncing of team members - fixed this in https://github.com/ConductorOne/baton-opsgenie/pull/3/commits/c6612877170fedefe94fa5f021e298a591851fcf