### PR TITLE
make escalation types not error

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -27,11 +27,6 @@ var (
 		DisplayName: "Team",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
 	}
-	resourceTypeEscalation = &v2.ResourceType{
-		Id:          "escalation",
-		DisplayName: "Escalation",
-		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
-	}
 	resourceTypeUser = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -27,6 +27,11 @@ var (
 		DisplayName: "Team",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
 	}
+	resourceTypeEscalation = &v2.ResourceType{
+		Id:          "escalation",
+		DisplayName: "Escalation",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+	}
 	resourceTypeUser = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",

--- a/pkg/connector/schedule.go
+++ b/pkg/connector/schedule.go
@@ -221,7 +221,7 @@ func (s *scheduleResourceType) Grants(ctx context.Context, resource *v2.Resource
 				),
 			)
 		case escalationParticipantType:
-			resourceType = resourceTypeEscalation.Id
+			continue
 		default:
 			return nil, "", nil, fmt.Errorf("opsgenie-connector: unknown participant type: %s", p.Type)
 		}

--- a/pkg/connector/schedule.go
+++ b/pkg/connector/schedule.go
@@ -20,8 +20,9 @@ const (
 	scheduleMember = "member"
 	scheduleOnCall = "on-call"
 
-	userParticipantType = "user"
-	teamParticipantType = "team"
+	userParticipantType       = "user"
+	teamParticipantType       = "team"
+	escalationParticipantType = "escalation"
 )
 
 type scheduleResourceType struct {
@@ -219,6 +220,8 @@ func (s *scheduleResourceType) Grants(ctx context.Context, resource *v2.Resource
 					},
 				),
 			)
+		case escalationParticipantType:
+			resourceType = resourceTypeEscalation.Id
 		default:
 			return nil, "", nil, fmt.Errorf("opsgenie-connector: unknown participant type: %s", p.Type)
 		}


### PR DESCRIPTION
Escalation types have a lot of info on them which maybe worth adding in the future. https://support.atlassian.com/opsgenie/docs/how-do-escalations-work-in-opsgenie/

For now this PR allows syncs to work even if there exist escalation types. 