### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up an OpsGenie connector"
+title:"Set up an Atlassian OpsGenie connector"
 description: "C1 provides identity governance for Opsgenie. Integrate your Opsgenie instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up an OpsGenie connector"
+og:title:"Set up an Atlassian OpsGenie connector"
 og:description: "C1 provides identity governance for Opsgenie. Integrate your Opsgenie instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian OpsGenie"
 ---
@@ -52,7 +52,7 @@ A user with the **Owner** or **Admin** role (or a custom user role with the **Ed
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Opsgenie connector
 
@@ -102,7 +102,7 @@ A user with the **Owner** or **Admin** role (or a custom user role with the **Ed
     </Step>
 </Steps>
 
-**That's it!** Your Opsgenie connector is now pulling access data into C1.
+**Done.** Your Opsgenie connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Opsgenie connector, hosted and run in your own environment.**
@@ -213,7 +213,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Opsgenie connector is now pulling access data into C1.
+**Done.** Your Opsgenie connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian OpsGenie connector"
+title: "Set up an Atlassian OpsGenie connector"
 description: "C1 provides identity governance for Opsgenie. Integrate your Opsgenie instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up an Atlassian OpsGenie connector"
+og:title: "Set up an Atlassian OpsGenie connector"
 og:description: "C1 provides identity governance for Opsgenie. Integrate your Opsgenie instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian OpsGenie"
 ---


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`