### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -41,15 +41,14 @@ func roleResource(ctx context.Context, roleName, roleId string) (*v2.Resource, e
 		"role_name": roleName,
 	}
 
-	roleTraitOptions := []res.RoleTraitOption{
-		res.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []res.RoleTraitOption{}
 
 	resource, err := res.NewRoleResource(
 		roleName,
 		resourceTypeRole,
 		roleId,
 		roleTraitOptions,
+		res.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/schedule.go
+++ b/pkg/connector/schedule.go
@@ -79,7 +79,8 @@ func scheduleResource(schedule *ogSchedule.Schedule) (*v2.Resource, error) {
 		schedule.Name,
 		resourceTypeSchedule,
 		schedule.Id,
-		[]rs.GroupTraitOption{rs.WithGroupProfile(profile)},
+		[]rs.GroupTraitOption{},
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err
@@ -147,17 +148,13 @@ func (s *scheduleResourceType) Grants(ctx context.Context, resource *v2.Resource
 	l := ctxzap.Extract(ctx)
 
 	// parse resource profile to get schedule members (users or teams)
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, "", nil, err
-	}
 
-	users, ok := getProfileStringArray(groupTrait.Profile, "schedule_users")
+	users, ok := getProfileStringArray(rs.GetProfile(resource), "schedule_users")
 	if !ok {
 		l.Info("opsgenie-connector: no users found for schedule resource")
 	}
 
-	teams, ok := getProfileStringArray(groupTrait.Profile, "schedule_teams")
+	teams, ok := getProfileStringArray(rs.GetProfile(resource), "schedule_teams")
 	if !ok {
 		l.Info("opsgenie-connector: no teams found for schedule resource")
 	}

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -35,15 +35,14 @@ func teamResource(ctx context.Context, team oteam.ListedTeams) (*v2.Resource, er
 		"team_description": team.Description,
 	}
 
-	groupTraitOptions := []res.GroupTraitOption{
-		res.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []res.GroupTraitOption{}
 
 	resource, err := res.NewGroupResource(
 		team.Name,
 		resourceTypeTeam,
 		team.Id,
 		groupTraitOptions,
+		res.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -30,9 +30,7 @@ func userResource(ctx context.Context, user user.User) (*v2.Resource, error) {
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmail(user.Username, true),
-		resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 	}
 
 	resource, err := resource.NewUserResource(
@@ -40,6 +38,8 @@ func userResource(ctx context.Context, user user.User) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
